### PR TITLE
Ensure that we deliver signals in creation order

### DIFF
--- a/app/models/talking_stick/signal.rb
+++ b/app/models/talking_stick/signal.rb
@@ -5,6 +5,8 @@ module TalkingStick
     belongs_to :recipient, class_name: "TalkingStick::Participant"
     validates :room, :sender, :recipient, presence: true
 
+    default_scope { order 'created_at ASC' }
+
     # The normal delegate method seems to not be working for an unknown reason
     def sender_guid
       self.sender.guid


### PR DESCRIPTION
This is to prevent a client receiving ICE candidates before receiving an Offer
