### PR TITLE
Remove the max-width limitation in the modal.

### DIFF
--- a/app/assets/stylesheets/talking_stick/application.css
+++ b/app/assets/stylesheets/talking_stick/application.css
@@ -39,6 +39,8 @@ body > .container-fluid > .row > [class^="col-xs-"]  {
 
 .modal #localvideo {
   max-height: 320px;
+  width: 100%;
+  max-width: none;
 }
 
 #partnervideos {


### PR DESCRIPTION
It applies the max width from the non-modal video in the modal, which makes the video small and off center.

<img width="900" alt="screen shot 2015-07-20 at 2 22 23 pm" src="https://cloud.githubusercontent.com/assets/829668/8775753/76f302a6-2eeb-11e5-8860-acf257a027cf.png">

becomes:

<img width="900" alt="screen shot 2015-07-20 at 2 28 09 pm" src="https://cloud.githubusercontent.com/assets/829668/8775768/99823602-2eeb-11e5-9cbf-0adf4995f6d8.png">
