### PR TITLE
Remove legacy Room handling

### DIFF
--- a/app/models/talking_stick/room.rb
+++ b/app/models/talking_stick/room.rb
@@ -17,7 +17,7 @@ module TalkingStick
     private
 
     def sluggify_name
-      self.slug = name.parameterize if !slug.present?
+      self.slug = name.parameterize unless slug.present?
     end
   end
 end

--- a/app/models/talking_stick/room.rb
+++ b/app/models/talking_stick/room.rb
@@ -7,11 +7,11 @@ module TalkingStick
 
     def self.find_or_create(slug:)
       slug = slug.parameterize
-      find_by(slug: slug) || find_by(id: slug) || create(name: slug.titleize, slug: slug)
+      find_by(slug: slug) || create(name: slug.titleize, slug: slug)
     end
 
     def to_param
-      slug || id
+      slug
     end
 
     private

--- a/db/migrate/20150722200822_add_slug_to_talking_stick_rooms.rb
+++ b/db/migrate/20150722200822_add_slug_to_talking_stick_rooms.rb
@@ -1,5 +1,11 @@
 class AddSlugToTalkingStickRooms < ActiveRecord::Migration
-  def change
+  def up
     add_column :talking_stick_rooms, :slug, :string
+    # Add slugs to the existing rooms
+    TalkingStick::Room.all.map &:save
+  end
+
+  def down
+    remove_column :talking_stick_rooms, :slug
   end
 end

--- a/spec/models/talking_stick/room_spec.rb
+++ b/spec/models/talking_stick/room_spec.rb
@@ -27,20 +27,6 @@ module TalkingStick
         expect(described_class.count).to eq 1
       end
 
-      it "finds a room by ID if the slug is not found" do
-        existing = described_class.create(name: "")
-
-        expect(described_class.find_or_create(slug: existing.id.to_s)).to eq existing
-        expect(described_class.count).to eq 1
-      end
-
-      it "prefers the slug to ID if a slug matches a possible room ID" do
-        numeric_id = described_class.create(name: "")
-        numeric_slug = described_class.create(name: numeric_id.id.to_s)
-
-        expect(described_class.find_or_create(slug: numeric_slug.slug)).to eq numeric_slug
-      end
-
       it "creates a room if the slug doesn't exist" do
         expect {
           described_class.find_or_create(slug: "Test")


### PR DESCRIPTION
This gets rid of our legacy handling of rooms without a slug. Since this will only affect us I didn't bother with a migration for legacy rooms, but I'm happy to add one if you think its necessary.

As discussed, its likely moot since we changed the mount point anyways.
