### PR TITLE
Feature/rails 5

### DIFF
--- a/app/models/talking_stick/application_record.rb
+++ b/app/models/talking_stick/application_record.rb
@@ -1,0 +1,5 @@
+module TalkingStick
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/app/models/talking_stick/participant.rb
+++ b/app/models/talking_stick/participant.rb
@@ -1,5 +1,5 @@
 module TalkingStick
-  class Participant < ActiveRecord::Base
+  class Participant < ApplicationRecord
     belongs_to :room
     has_many :signals_sent, class_name: 'Signal', foreign_key: 'sender_id', dependent: :destroy
     has_many :signals_received, class_name: 'Signal', foreign_key: 'recipient_id', dependent: :destroy

--- a/app/models/talking_stick/room.rb
+++ b/app/models/talking_stick/room.rb
@@ -1,5 +1,5 @@
 module TalkingStick
-  class Room < ActiveRecord::Base
+  class Room < ApplicationRecord
     has_many :participants, dependent: :destroy
     has_many :signals, dependent: :destroy
 

--- a/app/models/talking_stick/signal.rb
+++ b/app/models/talking_stick/signal.rb
@@ -1,5 +1,5 @@
 module TalkingStick
-  class Signal < ActiveRecord::Base
+  class Signal < ApplicationRecord
     belongs_to :room
     belongs_to :sender, class_name: "TalkingStick::Participant"
     belongs_to :recipient, class_name: "TalkingStick::Participant"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -24,9 +24,5 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end
-


### PR DESCRIPTION
Hi @lpradovera, 

This PR adds `ApplicationRecord` and removes the reference to `config.active_record.raise_in_transactional_callbacks`

The build now passes. 

Please check it out. 

Thanks! 