### PR TITLE
Feature/rails 5

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,8 @@
 # develop
 * *Breaking* HTML elements prefixed with `talking-stick-`
 * Improve ability to embed this engine into existing Rails applications by disabling `isolate_engine`
-* Support for Rails 3
+* We dropped support for Rails < 4.2
+* Support for Rails 4.2 and Rails 5.0
 
 # [1.0.0](https://github.com/mojolingo/talking_stick/compare/v0.0.1...v1.0.0) - [2016-01-02](https://rubygems.org/gems/talking_stick/versions/1.0.0)
 * First stable version of Talking Stick - see [README](https://github.com/mojolingo/talking_stick/blob/v1.0.0/README.md) for details

--- a/db/migrate/20150510181337_create_talking_stick_rooms.rb
+++ b/db/migrate/20150510181337_create_talking_stick_rooms.rb
@@ -1,4 +1,4 @@
-class CreateTalkingStickRooms < ActiveRecord::Migration[5.1]
+class CreateTalkingStickRooms < ActiveRecord::Migration[4.2]
   def change
     create_table :talking_stick_rooms do |t|
       t.string :name

--- a/db/migrate/20150510182258_create_talking_stick_participants.rb
+++ b/db/migrate/20150510182258_create_talking_stick_participants.rb
@@ -1,4 +1,4 @@
-class CreateTalkingStickParticipants < ActiveRecord::Migration[5.1]
+class CreateTalkingStickParticipants < ActiveRecord::Migration[4.2]
   def change
     create_table :talking_stick_participants do |t|
       t.string :name

--- a/db/migrate/20150511005922_create_talking_stick_signals.rb
+++ b/db/migrate/20150511005922_create_talking_stick_signals.rb
@@ -1,4 +1,4 @@
-class CreateTalkingStickSignals < ActiveRecord::Migration[5.1]
+class CreateTalkingStickSignals < ActiveRecord::Migration[4.2]
   def change
     create_table :talking_stick_signals do |t|
       t.belongs_to :room

--- a/db/migrate/20150722200822_add_slug_to_talking_stick_rooms.rb
+++ b/db/migrate/20150722200822_add_slug_to_talking_stick_rooms.rb
@@ -1,4 +1,4 @@
-class AddSlugToTalkingStickRooms < ActiveRecord::Migration[5.1]
+class AddSlugToTalkingStickRooms < ActiveRecord::Migration[4.2]
   def up
     add_column :talking_stick_rooms, :slug, :string
     # Add slugs to the existing rooms

--- a/lib/talking_stick/engine.rb
+++ b/lib/talking_stick/engine.rb
@@ -1,3 +1,5 @@
+require "jquery-rails"
+
 module TalkingStick
   class Engine < ::Rails::Engine
     engine_name "talking_stick"
@@ -5,8 +7,12 @@ module TalkingStick
     config.generators do |g|
       g.test_framework      :rspec,        :fixture => false
       g.fixture_replacement :factory_girl, :dir => 'spec/factories'
-      g.assets false
+      g.assets true
       g.helper false
+    end
+
+    initializer "talking_stick.assets.precompile" do |app|
+      app.config.assets.precompile += %w( application.js application.css )
     end
   end
 end

--- a/talking_stick.gemspec
+++ b/talking_stick.gemspec
@@ -17,13 +17,14 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  s.add_dependency 'rails', '~> 5.0'
-  s.add_dependency 'jquery-rails', '~> 4.0'
+  s.add_dependency 'rails', '>= 4.2', '< 5.1'
+  s.add_dependency 'jquery-rails', '>= 4.2'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'factory_girl_rails'
 end


### PR DESCRIPTION
Hey @benlangfeld @bklang,

This PR fixes a problem with `jquery-rails` - without these changes I keep getting:

```
ActionView::Template::Error (couldn't find file 'jquery' with type 'application/javascript'
Checked in these paths:
  /Users/etagwerker/Projects/power/talking_stick/spec/dummy/app/assets/images
  /Users/etagwerker/Projects/power/talking_stick/spec/dummy/app/assets/javascripts
  /Users/etagwerker/Projects/power/talking_stick/spec/dummy/app/assets/stylesheets
  /Users/etagwerker/Projects/power/talking_stick/app/assets/images
  /Users/etagwerker/Projects/power/talking_stick/app/assets/javascripts
  /Users/etagwerker/Projects/power/talking_stick/app/assets/stylesheets
  /Users/etagwerker/Projects/power/talking_stick/vendor/assets/javascripts):
    2: <html>
    3: <head>
    4:   <title>Dummy</title>
    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
    7:   <%= csrf_meta_tags %>
    8: </head>

app/views/layouts/application.html.erb:5:in `_app_views_layouts_application_html_erb___3224620718600104672_70276549540140'
  Rendering /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout
  Rendering /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
  Rendered /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (8.6ms)
  Rendering /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
  Rendered /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.3ms)
  Rendering /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
  Rendered /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (2.2ms)
  Rendered /Users/etagwerker/.rvm/gems/ruby-2.3.3@talkingstick/gems/actionpack-5.0.6/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (64.6ms)
```

Also, it changes the superclass of the migrations to `ActiveRecord::Migration[4.2]` - That way the gem will be compatible with Rails 4.2; 5.0; and 5.1. 

If we keep it compatible with those versions, I don't think we need a shim for `before_action`. Are you interested in making it compatible with Rails < 4.2? 

Please check it out and let me know if you have any comments.

Thanks! 